### PR TITLE
chore(deps): bump https://github.com/Sjyhne/scala-akka-http-quickstart.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -15,3 +15,4 @@ Dependency | Sources | Version | Mismatched versions
 [Sjyhne/tut-spring-boot-kotlin](https://github.com/Sjyhne/tut-spring-boot-kotlin.git) |  | []() | 
 [Sjyhne/rust-htto](https://github.com/Sjyhne/rust-htto.git) |  | []() | 
 [Sjyhne/dlang-http](https://github.com/Sjyhne/dlang-http.git) |  | []() | 
+[Sjyhne/scala-akka-http-quickstart](https://github.com/Sjyhne/scala-akka-http-quickstart.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -77,3 +77,9 @@ dependencies:
   url: https://github.com/Sjyhne/dlang-http.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: Sjyhne
+  repo: scala-akka-http-quickstart
+  url: https://github.com/Sjyhne/scala-akka-http-quickstart.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/sjyhne-scala-akka-http-quickstart-sr.yaml
+++ b/repositories/templates/sjyhne-scala-akka-http-quickstart-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: Sjyhne
+    provider: github
+    repository: scala-akka-http-quickstart
+  name: sjyhne-scala-akka-http-quickstart
+spec:
+  description: Imported application for Sjyhne/scala-akka-http-quickstart
+  httpCloneURL: https://github.com/Sjyhne/scala-akka-http-quickstart.git
+  org: Sjyhne
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: scala-akka-http-quickstart
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/Sjyhne/scala-akka-http-quickstart.git


### PR DESCRIPTION
Update [Sjyhne/scala-akka-http-quickstart](https://github.com/Sjyhne/scala-akka-http-quickstart.git) 

Command run was `jx create quickstart`